### PR TITLE
Let BS handle detecting the content encoding

### DIFF
--- a/fpclib/__init__.py
+++ b/fpclib/__init__.py
@@ -680,7 +680,7 @@ def get_soup(url, parser='html.parser', ignore_errs=True, **kwargs):
     try:
         rurl = normalize(url, True, True, True)
         with requests.get(rurl, **kwargs) as response:
-            soup = BeautifulSoup(response.text, parser)
+            soup = BeautifulSoup(response.content, parser)
         return soup
     except Exception as e:
         if ignore_errs:
@@ -2110,4 +2110,3 @@ DP_ISO = DateParser(r"<y>(\s*.??<m>)?(\s*.??<d>\w*)?")
 
 if __name__ == '__main__':
     test()
-    


### PR DESCRIPTION
Fixes getting metadata from https://aaronzbest.itch.io/rogue-emoji as passing `response.text` to BS4 makes mojibake due to requests thinking the encoding is ISO-8859-1 instead of UTF-8